### PR TITLE
Extend conflict detection to handle subdomain globs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,27 @@ async fn get_external_ip(ip_type: &IpType) -> Result<String, Error> {
     Ok(ip)
 }
 
+fn get_conflicts(
+    dns_records: Vec<DNSRecord>,
+    args: &Args,
+    rec: &DNSRecord,
+) -> (Vec<DNSRecord>, Vec<DNSRecord>) {
+    let target_hostname = format!(
+        "{}{}{}",
+        &args.subdomain,
+        if &args.subdomain == "" { "" } else { "." },
+        &args.domain
+    );
+    dns_records
+        .into_iter()
+        .filter(|r| match args.ip_type {
+            IpType::IPV4 => r.dns_type == "A",
+            IpType::IPV6 => r.dns_type == "AAAA",
+        })
+        .filter(|r| r.hostname == target_hostname)
+        .partition(|r| r.hostname == target_hostname && r.value == rec.value)
+}
+
 pub fn run(args: Args) -> Result<(), Error> {
     let ip = executor::block_on(get_external_ip(&args.ip_type))?;
 
@@ -125,18 +146,7 @@ pub fn run(args: Args) -> Result<(), Error> {
     let dns_records = netlify::get_dns_records(&args.domain, &args.token)?;
 
     // Match on subdomain
-    // TODO: what if subdomain == ""?
-    let (exact, conflicts): (Vec<DNSRecord>, Vec<DNSRecord>) = dns_records
-        .into_iter()
-        .filter(|r| match args.ip_type {
-            IpType::IPV4 => r.dns_type == "A",
-            IpType::IPV6 => r.dns_type == "AAAA",
-        })
-        .filter(|r| {
-            let v = r.hostname.split('.').collect::<Vec<&str>>();
-            v.len() == 3 && v[0] == args.subdomain
-        })
-        .partition(|r| r.hostname == rec.hostname && r.value == rec.value);
+    let (exact, conflicts) = get_conflicts(dns_records, &args, &rec);
 
     // Clear existing records for this subdomain, if any
     for r in conflicts {
@@ -190,5 +200,118 @@ mod test {
         if let Ok(_) = executor::block_on(get_external_ip(&IpType::IPV6)) {
             panic!("Should've gotten an error.");
         }
+    }
+
+    #[test]
+    fn test_conflicts() {
+        let dns_records = vec![
+            // Basic subdomain, exact and non-exact
+            DNSRecord {
+                hostname: "sub.helloworld.com".to_string(),
+                dns_type: "A".to_string(),
+                ttl: Some(3600),
+                id: Some("abc123".to_string()),
+                value: "1.2.3.4".to_string(),
+            },
+            DNSRecord {
+                hostname: "sub.helloworld.com".to_string(),
+                dns_type: "A".to_string(),
+                ttl: Some(3600),
+                id: Some("abc123".to_string()),
+                value: "9.9.9.9".to_string(),
+            },
+
+            // Glob subdomain, exact and non-exact
+            DNSRecord {
+                hostname: "*.sub.helloworld.com".to_string(),
+                dns_type: "A".to_string(),
+                ttl: Some(3600),
+                id: Some("abc123".to_string()),
+                value: "1.2.3.4".to_string(),
+            },
+            DNSRecord {
+                hostname: "*.sub.helloworld.com".to_string(),
+                dns_type: "A".to_string(),
+                ttl: Some(3600),
+                id: Some("abc123".to_string()),
+                value: "9.9.9.9".to_string(),
+            },
+            
+            // Empty subdomain, exact and non-exact
+            DNSRecord {
+                hostname: "helloworld.com".to_string(),
+                dns_type: "A".to_string(),
+                ttl: Some(3600),
+                id: Some("abc123".to_string()),
+                value: "1.2.3.4".to_string(),
+            },
+            DNSRecord {
+                hostname: "helloworld.com".to_string(),
+                dns_type: "A".to_string(),
+                ttl: Some(3600),
+                id: Some("abc123".to_string()),
+                value: "9.9.9.9".to_string(),
+            },
+        ];
+
+        let (glob_exact, glob_conflicts) = get_conflicts(
+            dns_records.clone(),
+            &Args {
+                domain: "helloworld.com".to_string(),
+                subdomain: "*.sub".to_string(),
+                ttl: 3600,
+                ip_type: IpType::IPV4,
+                token: "123".to_string(),
+            },
+            &DNSRecord {
+                hostname: "*.sub".to_string(),
+                dns_type: "A".to_string(),
+                ttl: Some(3600),
+                id: None,
+                value: "1.2.3.4".to_string(),
+            },
+        );
+        assert_eq!(glob_conflicts.len(), 1);
+        assert_eq!(glob_exact.len(), 1);
+
+        let (sub_exact, sub_conflicts) = get_conflicts(
+            dns_records.clone(),
+            &Args {
+                domain: "helloworld.com".to_string(),
+                subdomain: "sub".to_string(),
+                ttl: 3600,
+                ip_type: IpType::IPV4,
+                token: "123".to_string(),
+            },
+            &DNSRecord {
+                hostname: "sub".to_string(),
+                dns_type: "A".to_string(),
+                ttl: Some(3600),
+                id: None,
+                value: "1.2.3.4".to_string(),
+            },
+        );
+        assert_eq!(sub_conflicts.len(), 1);
+        assert_eq!(sub_exact.len(), 1);
+
+        let (empty_exact, empty_conflicts) = get_conflicts(
+            dns_records.clone(),
+            &Args {
+                domain: "helloworld.com".to_string(),
+                subdomain: "".to_string(),
+                ttl: 3600,
+                ip_type: IpType::IPV4,
+                token: "123".to_string(),
+            },
+            &DNSRecord {
+                hostname: "".to_string(),
+                dns_type: "A".to_string(),
+                ttl: Some(3600),
+                id: None,
+                value: "1.2.3.4".to_string(),
+            },
+        );
+        assert_eq!(empty_conflicts.len(), 1);
+        assert_eq!(empty_exact.len(), 1);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,7 +220,6 @@ mod test {
                 id: Some("abc123".to_string()),
                 value: "9.9.9.9".to_string(),
             },
-
             // Glob subdomain, exact and non-exact
             DNSRecord {
                 hostname: "*.sub.helloworld.com".to_string(),
@@ -236,7 +235,6 @@ mod test {
                 id: Some("abc123".to_string()),
                 value: "9.9.9.9".to_string(),
             },
-            
             // Empty subdomain, exact and non-exact
             DNSRecord {
                 hostname: "helloworld.com".to_string(),

--- a/src/netlify.rs
+++ b/src/netlify.rs
@@ -1,7 +1,7 @@
 use failure::{bail, Error};
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct DNSRecord {
     pub hostname: String,
     #[serde(rename = "type")]


### PR DESCRIPTION
For my use case, I want to set records for both `sub.mydomain.com` and `*.sub.mydomain.com`. I am currently doing this by running two commands:

    $ netlify-ddns -d mydomain.com -s 'sub' --ttl 3600 -t <token>
    $ netlify-ddns -d mydomain.com -s '*.sub' --ttl 3600 -t <token>

However, this was resulting in the glob subdomains never being deleted, because the existing Netlify DNS records were not being detected as duplicates. This was because the assumption of only 3 URL segments was baked into the code that filters for conflicts.

To handle this case, this PR figures out what the entire target hostname should be for the request, and compares the Netlify hostnames against that instead of breaking it up into segments. I also broke the conflict detection out into a separate function and added some tests that ensure the conflict/exact match detection still works as expected.

As a side effect, this handles the TODO item about empty subdomains.